### PR TITLE
Implement ads ingestion API, dashboard, and scraping CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,188 @@
-# Worker + D1 Database
+# Google Ads Transparency Collector (Worker + D1)
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/d1-template)
+This project turns the stock Cloudflare D1 template into a small data service for
+capturing creatives from the [Google Ads Transparency Center](https://adstransparency.google.com/).
+It consists of two parts:
 
-![Worker + D1 Template Preview](https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/cb7cb0a9-6102-4822-633c-b76b7bb25900/public)
+- **Cloudflare Worker + D1 database** – stores ad images and AI-generated insights,
+  exposes a REST API, and renders a small dashboard at `/`.
+- **Playwright-based scraper CLI** – opens the transparency site for a specific
+  advertiser, extracts all creative image URLs, optionally runs OpenAI Vision to
+  describe the content, and pushes the data into the Worker.
 
-<!-- dash-content-start -->
+## Features
 
-D1 is Cloudflare's native serverless SQL database ([docs](https://developers.cloudflare.com/d1/)). This project demonstrates using a Worker with a D1 binding to execute a SQL statement. A simple frontend displays the result of this query:
+- `POST /api/ads/batch` upserts creatives and insights into Cloudflare D1.
+- `GET /api/ads` returns stored creatives as JSON, filterable by advertiser.
+- `/` renders a quick dashboard showing the latest creatives, metadata and
+  recognised text or model summaries.
+- `npm run scrape` automates the Google Ads Transparency flow (search → advertiser
+  detail page → scroll → collect images) and can optionally call OpenAI Vision to
+  describe each creative.
 
-```SQL
-SELECT * FROM comments LIMIT 3;
-```
+## Prerequisites
 
-The D1 database is initialized with a `comments` table and this data:
+- Node.js 18 or newer.
+- A Cloudflare account with the D1 beta enabled.
+- (Optional) An OpenAI API key if you want the CLI to generate image summaries.
 
-```SQL
-INSERT INTO comments (author, content)
-VALUES
-    ('Kristian', 'Congrats!'),
-    ('Serena', 'Great job!'),
-    ('Max', 'Keep up the good work!')
-;
-```
+## Setup
 
-> [!IMPORTANT]
-> When using C3 to create this project, select "no" when it asks if you want to deploy. You need to follow this project's [setup steps](https://github.com/cloudflare/templates/tree/main/d1-template#setup-steps) before deploying.
-
-<!-- dash-content-end -->
-
-## Getting Started
-
-Outside of this repo, you can start a new project with this template using [C3](https://developers.cloudflare.com/pages/get-started/c3/) (the `create-cloudflare` CLI):
-
-```
-npm create cloudflare@latest -- --template=cloudflare/templates/d1-template
-```
-
-A live public deployment of this template is available at [https://d1-template.templates.workers.dev](https://d1-template.templates.workers.dev)
-
-## Setup Steps
-
-1. Install the project dependencies with a package manager of your choice:
+1. Install dependencies:
    ```bash
    npm install
    ```
-2. Create a [D1 database](https://developers.cloudflare.com/d1/get-started/) with the name "d1-template-database":
+2. If you intend to run the scraper, install a local Chromium build for Playwright:
    ```bash
-   npx wrangler d1 create d1-template-database
+   npx playwright install chromium
    ```
-   ...and update the `database_id` field in `wrangler.json` with the new database ID.
-3. Run the following db migration to initialize the database (notice the `migrations` directory in this project):
+3. Create (or update) a D1 database in `wrangler.json`, then apply the migrations:
    ```bash
-   npx wrangler d1 migrations apply --remote d1-template-database
+   # Local development database
+   npx wrangler d1 migrations apply DB --local
+
+   # Remote database (when you are ready to deploy)
+   npx wrangler d1 migrations apply DB --remote
    ```
-4. Deploy the project!
+4. Run the Worker locally with Wrangler:
    ```bash
-   npx wrangler deploy
+   npm run dev
    ```
+   The dashboard will be available at http://127.0.0.1:8787/.
+
+## API overview
+
+### `GET /api/ads`
+
+Returns the latest creatives stored in D1.
+
+Query parameters:
+
+| Parameter    | Description                                      |
+|--------------|--------------------------------------------------|
+| `advertiser` | Optional filter by advertiser name.              |
+| `limit`      | Number of creatives to return (default 20, max 100). |
+
+Example response (truncated):
+
+```json
+{
+  "advertiser": "吴中区长桥蛮红阁包子店",
+  "count": 2,
+  "ads": [
+    {
+      "id": 1,
+      "advertiserName": "吴中区长桥蛮红阁包子店",
+      "adIdentifier": "4f86…-1",
+      "imageUrl": "https://lh3.googleusercontent.com/...",
+      "metadata": {
+        "alt": "广告素材",
+        "textSnippets": ["匠心小笼包", "门店地址"]
+      },
+      "firstSeen": "2025-08-15T02:15:23.000Z",
+      "lastSeen": "2025-08-15T02:15:23.000Z",
+      "insights": [
+        {
+          "model": "openai:gpt-4.1-mini",
+          "insightType": "summary",
+          "insight": "广告展示蒸汽腾腾的小笼包，并强调门店地址和电话…",
+          "updatedAt": "2025-08-15T02:16:10.000Z"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### `POST /api/ads/batch`
+
+Stores a batch of creatives and optional model insights. Existing records are
+updated based on the tuple `(advertiser, platform, adIdentifier)`.
+
+Request body:
+
+```json
+{
+  "advertiser": "吴中区长桥蛮红阁包子店",
+  "platform": "google_ads_transparency",
+  "scrapedAt": "2025-08-15T02:15:23.000Z",
+  "ads": [
+    {
+      "adIdentifier": "4f86...-1",
+      "imageUrl": "https://lh3.googleusercontent.com/...",
+      "seenAt": "2025-08-15T02:15:23.000Z",
+      "metadata": {
+        "alt": "广告素材",
+        "textSnippets": ["匠心小笼包", "门店地址"]
+      },
+      "insights": [
+        {
+          "model": "openai:gpt-4.1-mini",
+          "insightType": "summary",
+          "insight": "广告展示蒸汽腾腾的小笼包，并强调门店地址和电话。",
+          "rawResponse": { "tokens": 225 }
+        }
+      ]
+    }
+  ]
+}
+```
+
+On success the Worker responds with:
+
+```json
+{
+  "advertiser": "吴中区长桥蛮红阁包子店",
+  "platform": "google_ads_transparency",
+  "processedAds": 1
+}
+```
+
+## Scraper CLI (`npm run scrape`)
+
+The `scripts/scrapeAds.ts` helper automates the workflow described in the user
+request. Example usage:
+
+```bash
+# Scrape creatives for the advertiser and push them into a local dev worker
+WORKER_API_BASE="http://127.0.0.1:8787" npm run scrape -- --advertiser "吴中区长桥蛮红阁包子店" --start-date 2025-08-15 --end-date 2025-08-15
+```
+
+Notable options:
+
+| Flag | Description |
+|------|-------------|
+| `--region` / `--platform` | Override the transparency filters (defaults: `anywhere`, `SEARCH`). |
+| `--max-scrolls` / `--scroll-delay` | Tune how aggressively the page is scrolled to load more creatives. |
+| `--worker` | Base URL of the Worker API. If omitted the script prints the payload to stdout. |
+| `--worker-token` | Optional bearer token added as `Authorization: Bearer …` when calling the Worker. |
+| `--skip-vision` | Disable OpenAI image analysis. |
+| `--vision-model` | Choose a different OpenAI Responses model (default `gpt-4.1-mini`). |
+| `--headful` | Launch Chromium with a visible window for debugging. |
+
+Environment variables can also be used (`WORKER_API_BASE`, `WORKER_API_TOKEN`,
+`OPENAI_API_KEY`, etc.). When `OPENAI_API_KEY` is present the script will call
+OpenAI's Responses API to generate a textual summary of each creative; if the key
+is missing or `--skip-vision` is set, the vision step is skipped automatically.
+
+## Dashboard
+
+Visiting `/` renders the latest creatives using the data in D1. Each card shows:
+
+- creative image (click to open the original URL),
+- identifier, first/last seen timestamps, platform,
+- captured metadata such as recognised text snippets,
+- model insights with expandable raw JSON payloads.
+
+## Development tips
+
+- The migrations folder now contains `0002_create_ads_tables.sql`, which drops
+  the original demo `comments` table and creates the new `ads` and `ad_insights`
+  tables.
+- When developing locally you can inspect the database with
+  `npx wrangler d1 execute DB --local --command "SELECT * FROM ads"`.
+- The scraper uses Playwright; if you run it in a CI environment make sure the
+  necessary browser binaries are installed (`npx playwright install`).
+- Be respectful of the target site's terms of service. The script includes
+  conservative scroll delays, but you may still want to adjust them or add
+  throttling depending on your deployment environment.

--- a/migrations/0002_create_ads_tables.sql
+++ b/migrations/0002_create_ads_tables.sql
@@ -1,0 +1,31 @@
+DROP TABLE IF EXISTS ad_insights;
+DROP TABLE IF EXISTS ads;
+DROP TABLE IF EXISTS comments;
+
+CREATE TABLE ads (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  advertiser_name TEXT NOT NULL,
+  platform TEXT NOT NULL DEFAULT 'google_ads_transparency',
+  ad_identifier TEXT NOT NULL,
+  image_url TEXT NOT NULL,
+  metadata TEXT,
+  first_seen TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_seen TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX idx_ads_unique_identifier
+  ON ads(advertiser_name, platform, ad_identifier);
+
+CREATE TABLE ad_insights (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ad_id INTEGER NOT NULL REFERENCES ads(id) ON DELETE CASCADE,
+  model TEXT NOT NULL,
+  insight_type TEXT NOT NULL DEFAULT 'summary',
+  insight TEXT NOT NULL,
+  raw_response TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX idx_ad_insights_unique
+  ON ad_insights(ad_id, model, insight_type);

--- a/package.json
+++ b/package.json
@@ -19,11 +19,16 @@
     "preview_image_url": "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/cb7cb0a9-6102-4822-633c-b76b7bb25900/public",
     "publish": true
   },
+  "dependencies": {
+    "openai": "4.77.0"
+  },
   "devDependencies": {
+    "playwright": "1.49.0",
     "typescript": "5.8.3",
     "wrangler": "4.21.x"
   },
   "scripts": {
+    "scrape": "node scripts/scrapeAds.mjs",
     "cf-typegen": "wrangler types",
     "check": "tsc && wrangler deploy --dry-run",
     "deploy": "wrangler deploy",

--- a/scripts/scrapeAds.mjs
+++ b/scripts/scrapeAds.mjs
@@ -1,0 +1,500 @@
+import { chromium } from 'playwright';
+import { createHash } from 'node:crypto';
+import OpenAI from 'openai';
+
+const DEFAULT_REGION = 'anywhere';
+const DEFAULT_PLATFORM = 'SEARCH';
+const DEFAULT_SCROLLS = 16;
+const DEFAULT_SCROLL_DELAY_MS = 1200;
+const DEFAULT_VISION_MODEL = 'gpt-4.1-mini';
+
+async function main() {
+  const options = parseCliArgs(process.argv.slice(2));
+  const searchUrl = buildSearchUrl(options);
+
+  log(`Launching Chromium (headless=${options.headless})`);
+  const browser = await chromium.launch({ headless: options.headless });
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await context.newPage();
+
+  const scrapedAt = new Date().toISOString();
+
+  try {
+    log(`Navigating to ${searchUrl}`);
+    await page.goto(searchUrl, { waitUntil: 'domcontentloaded' });
+
+    await searchForAdvertiser(page, options.advertiser);
+    await waitForInitialResults(page);
+
+    const ads = await collectAdImages(page, options.maxScrolls, options.scrollDelayMs);
+    log(`Collected ${ads.length} unique creative images.`);
+
+    if (ads.length === 0) {
+      log('No creatives detected on the page. Exiting.');
+      return;
+    }
+
+    const enrichedAds = await enrichAds(ads, options, scrapedAt);
+    const payload = {
+      advertiser: options.advertiser,
+      platform: 'google_ads_transparency',
+      scrapedAt,
+      ads: enrichedAds,
+    };
+
+    if (options.workerApiBase) {
+      await sendBatchToWorker(options.workerApiBase, payload, options.workerAuthToken);
+    } else {
+      console.log(JSON.stringify(payload, null, 2));
+      log('Worker endpoint not configured; printed payload to stdout instead.');
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+function parseCliArgs(argv) {
+  const parsed = {};
+  const positional = [];
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const trimmed = arg.slice(2);
+      if (trimmed.includes('=')) {
+        const [key, value] = trimmed.split('=', 2);
+        parsed[key] = value;
+      } else {
+        const next = argv[i + 1];
+        if (next && !next.startsWith('--')) {
+          parsed[trimmed] = next;
+          i += 1;
+        } else {
+          parsed[trimmed] = true;
+        }
+      }
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  const advertiser = stringOption(parsed, 'advertiser') ?? positional[0] ?? process.env.AD_TRANSPARENCY_ADVERTISER;
+  if (!advertiser || advertiser.trim().length === 0) {
+    printUsage();
+    throw new Error('Missing advertiser name. Provide it via --advertiser or as a positional argument.');
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+  const startDate = stringOption(parsed, 'start-date') ?? process.env.AD_TRANSPARENCY_START_DATE ?? today;
+  const endDate = stringOption(parsed, 'end-date') ?? process.env.AD_TRANSPARENCY_END_DATE ?? startDate;
+  const region = stringOption(parsed, 'region') ?? process.env.AD_TRANSPARENCY_REGION ?? DEFAULT_REGION;
+  const platform = stringOption(parsed, 'platform') ?? process.env.AD_TRANSPARENCY_PLATFORM ?? DEFAULT_PLATFORM;
+  const maxScrolls = numericOption(parsed, 'max-scrolls', DEFAULT_SCROLLS);
+  const scrollDelayMs = numericOption(parsed, 'scroll-delay', DEFAULT_SCROLL_DELAY_MS);
+  const workerApiBase = stringOption(parsed, 'worker') ?? process.env.WORKER_API_BASE;
+  const workerAuthToken = stringOption(parsed, 'worker-token') ?? process.env.WORKER_API_TOKEN ?? process.env.WORKER_AUTH_TOKEN;
+  const skipVision = booleanOption(parsed, 'skip-vision') || process.env.SKIP_VISION === 'true';
+  const openAiModel = stringOption(parsed, 'vision-model') ?? process.env.OPENAI_VISION_MODEL ?? DEFAULT_VISION_MODEL;
+  const headless = !booleanOption(parsed, 'headful');
+  const searchUrl = stringOption(parsed, 'search-url') ?? process.env.AD_TRANSPARENCY_URL;
+
+  return {
+    advertiser: advertiser.trim(),
+    region: region.trim(),
+    platform: platform.trim(),
+    startDate: startDate.trim(),
+    endDate: endDate.trim(),
+    maxScrolls,
+    scrollDelayMs,
+    workerApiBase,
+    workerAuthToken: workerAuthToken?.trim() || undefined,
+    skipVision,
+    openAiModel: openAiModel.trim(),
+    headless,
+    searchUrl: searchUrl?.trim() || undefined,
+  };
+}
+
+function buildSearchUrl(options) {
+  if (options.searchUrl) {
+    return options.searchUrl;
+  }
+
+  const params = new URLSearchParams({
+    region: options.region,
+    platform: options.platform,
+    'start-date': options.startDate,
+    'end-date': options.endDate,
+  });
+  return `https://adstransparency.google.com/?${params.toString()}`;
+}
+
+async function searchForAdvertiser(page, advertiser) {
+  log(`Searching for advertiser "${advertiser}"`);
+  const searchSelectors = [
+    'input[aria-label="Search ads"]',
+    'input[aria-label="Search by advertiser or keyword"]',
+    'input[type="search"]',
+    'input',
+  ];
+
+  let searchHandle = null;
+  for (const selector of searchSelectors) {
+    searchHandle = await page.$(selector);
+    if (searchHandle) {
+      break;
+    }
+  }
+
+  if (!searchHandle) {
+    throw new Error('Unable to locate the search input on the transparency page.');
+  }
+
+  await searchHandle.click({ clickCount: 3 });
+  await searchHandle.fill('');
+  await page.waitForTimeout(200);
+  await searchHandle.type(advertiser, { delay: 40 });
+  await page.waitForTimeout(600);
+
+  const dropdownOption = page.locator('[role="listbox"] [role="option"]');
+  if ((await dropdownOption.count()) > 0) {
+    await dropdownOption.first().click();
+    await page.waitForTimeout(800);
+  } else {
+    await page.keyboard.press('Enter');
+  }
+}
+
+async function waitForInitialResults(page) {
+  await page.waitForLoadState('networkidle', { timeout: 20000 }).catch(() => undefined);
+  await page.waitForFunction(
+    () => {
+      const main = document.querySelector('main');
+      if (!main) {
+        return false;
+      }
+      return main.querySelectorAll('img').length > 0;
+    },
+    { timeout: 20000 },
+  );
+}
+
+async function collectAdImages(page, maxScrolls, scrollDelayMs) {
+  const seen = new Map();
+  let stagnantRounds = 0;
+
+  for (let round = 0; round < maxScrolls; round += 1) {
+    const beforeCount = seen.size;
+    const chunk = await page.evaluate(() => {
+      const nodes = Array.from(document.querySelectorAll('img'));
+      const entries = [];
+
+      for (const node of nodes) {
+        const src = node.getAttribute('src') || node.getAttribute('data-src');
+        if (!src || !/^https?:/i.test(src)) {
+          continue;
+        }
+        if (!/googleusercontent|ggpht|gstatic|googleapis|doubleclick/i.test(src)) {
+          continue;
+        }
+        const alt = node.getAttribute('alt') || undefined;
+        const container =
+          node.closest('article') ||
+          node.closest('[role="listitem"]') ||
+          node.closest('div[data-testid]') ||
+          node.parentElement;
+
+        const textSnippets = [];
+        if (container) {
+          const textNodes = Array.from(
+            container.querySelectorAll(
+              "h1, h2, h3, h4, h5, h6, p, span, div[role='text'], [data-text]",
+            ),
+          );
+          for (const element of textNodes) {
+            const content = element.textContent?.trim();
+            if (content && content.length > 1 && content.length <= 600) {
+              textSnippets.push(content);
+            }
+          }
+        }
+
+        entries.push({ imageUrl: src, alt, textSnippets });
+      }
+
+      return entries;
+    });
+
+    for (const entry of chunk) {
+      const existing = seen.get(entry.imageUrl);
+      if (existing) {
+        if (!existing.alt && entry.alt) {
+          existing.alt = entry.alt;
+        }
+        existing.textSnippets = mergeSnippets(existing.textSnippets, entry.textSnippets);
+      } else {
+        seen.set(entry.imageUrl, {
+          imageUrl: entry.imageUrl,
+          alt: entry.alt,
+          textSnippets: uniqueSnippets(entry.textSnippets),
+        });
+      }
+    }
+
+    if (seen.size === beforeCount) {
+      stagnantRounds += 1;
+    } else {
+      stagnantRounds = 0;
+    }
+
+    if (stagnantRounds >= 3) {
+      break;
+    }
+
+    const loadMoreButton = page.locator('button:has-text("Load more")');
+    if ((await loadMoreButton.count()) > 0) {
+      await loadMoreButton.first().click({ trial: false }).catch(() => undefined);
+      await page.waitForTimeout(scrollDelayMs);
+      continue;
+    }
+
+    await page.evaluate(() => {
+      window.scrollBy({ top: window.innerHeight * 0.85, behavior: 'smooth' });
+    });
+    await page.waitForTimeout(scrollDelayMs);
+  }
+
+  return Array.from(seen.values());
+}
+
+async function enrichAds(ads, options, seenAt) {
+  const payloads = [];
+  const visionClient = createVisionClient(options.skipVision, options.openAiModel);
+
+  for (let index = 0; index < ads.length; index += 1) {
+    const ad = ads[index];
+    const adIdentifier = createAdIdentifier(ad.imageUrl, index);
+    const metadata = {
+      alt: ad.alt,
+      textSnippets: ad.textSnippets,
+      source: {
+        region: options.region,
+        platform: options.platform,
+        startDate: options.startDate,
+        endDate: options.endDate,
+      },
+    };
+
+    const insights = [];
+
+    if (visionClient) {
+      log(`Analyzing creative ${index + 1}/${ads.length} with ${visionClient.model}`);
+      const analysis = await analyzeImageWithOpenAi(visionClient.client, visionClient.model, ad.imageUrl);
+      if (analysis) {
+        insights.push({
+          model: `openai:${visionClient.model}`,
+          insight: analysis.summary,
+          insightType: 'summary',
+          rawResponse: analysis.raw,
+          createdAt: analysis.createdAt,
+        });
+      }
+    }
+
+    payloads.push({
+      adIdentifier,
+      imageUrl: ad.imageUrl,
+      metadata,
+      insights,
+      seenAt,
+    });
+  }
+
+  return payloads;
+}
+
+function createVisionClient(skipVision, model) {
+  if (skipVision) {
+    log('Skipping image analysis (--skip-vision)');
+    return null;
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    log('OPENAI_API_KEY is not set. Vision analysis will be skipped.');
+    return null;
+  }
+
+  const client = new OpenAI({ apiKey });
+  return { client, model };
+}
+
+async function analyzeImageWithOpenAi(client, model, imageUrl) {
+  try {
+    const prompt =
+      'You are reviewing an advertisement from the Google Ads Transparency Center. ' +
+      'Provide a concise summary of the visual content and any prominent text. ' +
+      'List call-to-action messaging, promotion details, political or geographic references, and visible disclaimers.';
+
+    const response = await client.responses.create({
+      model,
+      input: [
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: prompt },
+            { type: 'input_image', image_url: imageUrl },
+          ],
+        },
+      ],
+      max_output_tokens: 400,
+      temperature: 0.2,
+    });
+
+    const summary = extractResponseText(response);
+    if (!summary) {
+      return null;
+    }
+
+    const createdAt = new Date().toISOString();
+    const raw = typeof response.toJSON === 'function' ? response.toJSON() : response;
+
+    return { summary: summary.trim(), raw, createdAt };
+  } catch (error) {
+    console.warn(`[vision] Failed to analyze ${imageUrl}:`, error);
+    return null;
+  }
+}
+
+function extractResponseText(response) {
+  if (!response) {
+    return null;
+  }
+
+  if (typeof response.output_text === 'string' && response.output_text.trim().length > 0) {
+    return response.output_text;
+  }
+
+  const segments = Array.isArray(response.output) ? response.output : [];
+  for (const segment of segments) {
+    const contentPieces = Array.isArray(segment.content) ? segment.content : [];
+    for (const piece of contentPieces) {
+      if (piece && typeof piece.text === 'string' && piece.text.trim().length > 0) {
+        return piece.text;
+      }
+    }
+  }
+
+  return null;
+}
+
+async function sendBatchToWorker(apiBase, payload, token) {
+  const endpoint = new URL('/api/ads/batch', ensureTrailingSlash(apiBase));
+  log(`Uploading ${payload.ads.length} creatives to ${endpoint.toString()}`);
+
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(endpoint.toString(), {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Worker responded with ${response.status}: ${text}`);
+  }
+
+  const result = await response.json().catch(() => undefined);
+  log(`Worker stored ${(result === null || result === void 0 ? void 0 : result.processedAds) ?? payload.ads.length} creatives successfully.`);
+}
+
+function createAdIdentifier(imageUrl, index) {
+  const hash = createHash('sha1').update(imageUrl).digest('hex');
+  return `${hash}-${index + 1}`;
+}
+
+function mergeSnippets(existing, incoming) {
+  const merged = existing.slice(0, 20);
+  const seen = new Set(merged);
+  for (const snippet of incoming) {
+    if (!seen.has(snippet)) {
+      merged.push(snippet);
+      seen.add(snippet);
+    }
+    if (merged.length >= 20) {
+      break;
+    }
+  }
+  return merged;
+}
+
+function uniqueSnippets(snippets) {
+  return Array.from(new Set(snippets)).slice(0, 20);
+}
+
+function ensureTrailingSlash(url) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+function stringOption(parsed, key) {
+  const value = parsed[key];
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value;
+  }
+  return undefined;
+}
+
+function numericOption(parsed, key, fallback) {
+  const value = parsed[key];
+  if (typeof value === 'string') {
+    const parsedNumber = Number.parseInt(value, 10);
+    if (!Number.isNaN(parsedNumber)) {
+      return parsedNumber;
+    }
+  }
+  return fallback;
+}
+
+function booleanOption(parsed, key) {
+  const value = parsed[key];
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    return value === 'true' || value === '1';
+  }
+  return false;
+}
+
+function printUsage() {
+  console.log(`Usage: npm run scrape -- --advertiser "名称" [options]
+
+Options:
+  --start-date YYYY-MM-DD    Set the start date for the transparency query (default: today)
+  --end-date YYYY-MM-DD      Set the end date (default: start date)
+  --region REGION            Geographic region (default: anywhere)
+  --platform PLATFORM        Ad platform (default: SEARCH)
+  --max-scrolls N            Maximum scroll iterations while collecting creatives (default: ${DEFAULT_SCROLLS})
+  --scroll-delay MS          Delay between scroll iterations in milliseconds (default: ${DEFAULT_SCROLL_DELAY_MS})
+  --worker URL               Cloudflare Worker base URL to store results
+  --worker-token TOKEN       Bearer token to send in the Authorization header
+  --skip-vision              Skip image analysis with OpenAI Vision
+  --vision-model MODEL       Vision model identifier (default: ${DEFAULT_VISION_MODEL})
+  --headful                  Launch Chromium with a visible window for debugging
+`);
+}
+
+function log(message) {
+  console.log(`[scraper] ${message}`);
+}
+
+main().catch((error) => {
+  console.error('[scraper] Unexpected failure:', error);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,439 @@
-import { renderHtml } from "./renderHtml";
+import { renderHtml, type RenderableAd } from "./renderHtml";
+
+type BatchInsight = {
+  model: string;
+  insight: string;
+  insightType?: string;
+  rawResponse?: unknown;
+  createdAt?: string;
+};
+
+type BatchAd = {
+  adIdentifier: string;
+  imageUrl: string;
+  metadata?: Record<string, unknown>;
+  insights: BatchInsight[];
+  seenAt?: string;
+};
+
+type BatchPayload = {
+  advertiser: string;
+  platform?: string;
+  scrapedAt?: string;
+  ads: BatchAd[];
+};
+
+type StoredInsight = {
+  id: number;
+  model: string;
+  insightType: string;
+  insight: string;
+  rawResponse: unknown | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type StoredAd = {
+  id: number;
+  advertiserName: string;
+  platform: string;
+  adIdentifier: string;
+  imageUrl: string;
+  metadata: Record<string, unknown> | null;
+  firstSeen: string;
+  lastSeen: string;
+  insights: StoredInsight[];
+};
+
+const JSON_HEADERS = {
+  "content-type": "application/json; charset=utf-8",
+};
+
+class HttpError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = "HttpError";
+  }
+}
 
 export default {
   async fetch(request, env) {
-    const stmt = env.DB.prepare("SELECT * FROM comments LIMIT 3");
-    const { results } = await stmt.all();
+    const url = new URL(request.url);
 
-    return new Response(renderHtml(JSON.stringify(results, null, 2)), {
-      headers: {
-        "content-type": "text/html",
-      },
-    });
+    try {
+      if (request.method === "GET" && url.pathname === "/") {
+        const advertiser = optionalString(url.searchParams.get("advertiser"));
+        const limit = clampLimit(url.searchParams.get("limit"));
+        const ads = await fetchAds(env, { advertiser, limit });
+        return new Response(renderHtml({ advertiser, ads }), {
+          headers: {
+            "content-type": "text/html; charset=utf-8",
+          },
+        });
+      }
+
+      if (request.method === "GET" && url.pathname === "/api/ads") {
+        const advertiser = optionalString(url.searchParams.get("advertiser"));
+        const limit = clampLimit(url.searchParams.get("limit"));
+        const ads = await fetchAds(env, { advertiser, limit });
+        return Response.json(
+          {
+            advertiser: advertiser ?? null,
+            count: ads.length,
+            ads,
+          },
+          { headers: JSON_HEADERS },
+        );
+      }
+
+      if (request.method === "POST" && url.pathname === "/api/ads/batch") {
+        const body = await request.json().catch(() => {
+          throw new HttpError(400, "Request body must be valid JSON.");
+        });
+        const payload = parseBatchPayload(body);
+        const result = await storeAdsBatch(env, payload);
+        return Response.json(result, { status: 201, headers: JSON_HEADERS });
+      }
+    } catch (error) {
+      if (error instanceof HttpError) {
+        return Response.json(
+          {
+            error: error.message,
+            details: error.details ?? null,
+          },
+          { status: error.status, headers: JSON_HEADERS },
+        );
+      }
+
+      console.error("Unexpected error", error);
+      return new Response("Internal Server Error", { status: 500 });
+    }
+
+    return new Response("Not Found", { status: 404 });
   },
 } satisfies ExportedHandler<Env>;
+
+function optionalString(value: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function clampLimit(value: string | null): number {
+  if (!value) {
+    return 20;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    return 20;
+  }
+
+  return Math.max(1, Math.min(100, parsed));
+}
+
+function parseBatchPayload(body: unknown): BatchPayload {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new HttpError(400, "Request body must be an object.");
+  }
+
+  const raw = body as Record<string, unknown>;
+  const advertiser = ensureNonEmptyString(raw.advertiser, "advertiser");
+  const platformValue = typeof raw.platform === "string" ? raw.platform : null;
+  const platform = optionalString(platformValue) ?? "google_ads_transparency";
+
+  const scrapedAt = parseOptionalIsoDate(raw.scrapedAt, "scrapedAt");
+
+  if (!Array.isArray(raw.ads) || raw.ads.length === 0) {
+    throw new HttpError(400, "Field ads must be a non-empty array.");
+  }
+
+  const ads = raw.ads.map((value, index) => parseAdPayload(value, index));
+
+  return {
+    advertiser,
+    platform,
+    scrapedAt,
+    ads,
+  };
+}
+
+function parseAdPayload(value: unknown, index: number): BatchAd {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new HttpError(400, "Ad entry at index " + index + " must be an object.");
+  }
+
+  const raw = value as Record<string, unknown>;
+  const adIdentifier = ensureNonEmptyString(raw.adIdentifier, "ads[" + index + "].adIdentifier");
+  const imageUrl = ensureNonEmptyString(raw.imageUrl, "ads[" + index + "].imageUrl");
+
+  let metadata: Record<string, unknown> | undefined;
+  if (raw.metadata !== undefined) {
+    if (!isPlainObject(raw.metadata)) {
+      throw new HttpError(400, "ads[" + index + "].metadata must be an object when provided.");
+    }
+    metadata = raw.metadata as Record<string, unknown>;
+  }
+
+  const seenAt = parseOptionalIsoDate(raw.seenAt, "ads[" + index + "].seenAt");
+
+  const insightsRaw = raw.insights;
+  let insights: BatchInsight[] = [];
+  if (insightsRaw !== undefined) {
+    if (!Array.isArray(insightsRaw)) {
+      throw new HttpError(400, "ads[" + index + "].insights must be an array when provided.");
+    }
+
+    insights = insightsRaw.map((entry, insightIndex) => parseInsight(entry, index, insightIndex));
+  }
+
+  return {
+    adIdentifier,
+    imageUrl,
+    metadata,
+    insights,
+    seenAt,
+  };
+}
+
+function parseInsight(value: unknown, adIndex: number, insightIndex: number): BatchInsight {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new HttpError(400, "ads[" + adIndex + "].insights[" + insightIndex + "] must be an object.");
+  }
+
+  const raw = value as Record<string, unknown>;
+
+  const model = ensureNonEmptyString(raw.model, "ads[" + adIndex + "].insights[" + insightIndex + "].model");
+  const insight = ensureNonEmptyString(raw.insight, "ads[" + adIndex + "].insights[" + insightIndex + "].insight");
+  const insightTypeValue = typeof raw.insightType === "string" ? raw.insightType : null;
+  const insightType = optionalString(insightTypeValue) ?? "summary";
+  const createdAt = parseOptionalIsoDate(raw.createdAt, "ads[" + adIndex + "].insights[" + insightIndex + "].createdAt");
+
+  return {
+    model,
+    insight,
+    insightType,
+    rawResponse: raw.rawResponse,
+    createdAt,
+  };
+}
+
+function ensureNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new HttpError(400, "Field " + field + " must be a string.");
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new HttpError(400, "Field " + field + " cannot be empty.");
+  }
+
+  return trimmed;
+}
+
+function parseOptionalIsoDate(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    throw new HttpError(400, "Field " + field + " must be a string when provided.");
+  }
+
+  if (!isValidIsoDate(value)) {
+    throw new HttpError(400, "Field " + field + " must be an ISO 8601 timestamp.");
+  }
+
+  return value;
+}
+
+function isValidIsoDate(value: string): boolean {
+  if (!value.trim()) {
+    return false;
+  }
+
+  const date = new Date(value);
+  return Number.isFinite(date.getTime());
+}
+
+function isPlainObject(value: unknown): boolean {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function storeAdsBatch(env: Env, payload: BatchPayload) {
+  const platform = payload.platform ?? "google_ads_transparency";
+  const defaultTimestamp = payload.scrapedAt ?? new Date().toISOString();
+  const stored: { adId: number; adIdentifier: string }[] = [];
+
+  const insertAdSql = [
+    "INSERT INTO ads (advertiser_name, platform, ad_identifier, image_url, metadata, first_seen, last_seen)",
+    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+    "ON CONFLICT(advertiser_name, platform, ad_identifier)",
+    "DO UPDATE SET",
+    "  image_url=excluded.image_url,",
+    "  metadata=COALESCE(excluded.metadata, ads.metadata),",
+    "  last_seen=excluded.last_seen",
+  ].join(" ");
+
+  const upsertInsightSql = [
+    "INSERT INTO ad_insights (ad_id, model, insight_type, insight, raw_response, created_at, updated_at)",
+    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+    "ON CONFLICT(ad_id, model, insight_type)",
+    "DO UPDATE SET",
+    "  insight=excluded.insight,",
+    "  raw_response=excluded.raw_response,",
+    "  updated_at=excluded.updated_at",
+  ].join(" ");
+
+  for (const ad of payload.ads) {
+    const seenAt = ad.seenAt ?? defaultTimestamp;
+    const metadataJson = ad.metadata ? safeStringify(ad.metadata) : null;
+
+    await env.DB.prepare(insertAdSql)
+      .bind(payload.advertiser, platform, ad.adIdentifier, ad.imageUrl, metadataJson, seenAt, seenAt)
+      .run();
+
+    const adRow = await env.DB.prepare(
+      "SELECT id FROM ads WHERE advertiser_name = ? AND platform = ? AND ad_identifier = ?"
+    )
+      .bind(payload.advertiser, platform, ad.adIdentifier)
+      .first<{ id: number }>();
+
+    if (!adRow) {
+      throw new HttpError(500, "Failed to look up stored ad record.");
+    }
+
+    const adId = adRow.id;
+    stored.push({ adId, adIdentifier: ad.adIdentifier });
+
+    if (ad.insights.length > 0) {
+      for (const insight of ad.insights) {
+        const createdAt = insight.createdAt ?? seenAt;
+        const raw = insight.rawResponse !== undefined ? safeStringify(insight.rawResponse) : null;
+
+        await env.DB.prepare(upsertInsightSql)
+          .bind(adId, insight.model, insight.insightType ?? "summary", insight.insight, raw, createdAt, seenAt)
+          .run();
+      }
+    }
+  }
+
+  return {
+    advertiser: payload.advertiser,
+    platform,
+    processedAds: stored.length,
+  };
+}
+
+async function fetchAds(env: Env, options: { advertiser?: string; limit: number }): Promise<RenderableAd[]> {
+  const baseQuery = "SELECT id, advertiser_name, platform, ad_identifier, image_url, metadata, first_seen, last_seen FROM ads";
+
+  let stmt: D1PreparedStatement;
+  if (options.advertiser) {
+    const query = baseQuery + " WHERE advertiser_name = ? ORDER BY last_seen DESC LIMIT ?";
+    stmt = env.DB.prepare(query).bind(options.advertiser, options.limit);
+  } else {
+    const query = baseQuery + " ORDER BY last_seen DESC LIMIT ?";
+    stmt = env.DB.prepare(query).bind(options.limit);
+  }
+
+  const adResult = await stmt.all<{
+    id: number;
+    advertiser_name: string;
+    platform: string;
+    ad_identifier: string;
+    image_url: string;
+    metadata: string | null;
+    first_seen: string;
+    last_seen: string;
+  }>();
+
+  const adRows = adResult.results ?? [];
+  if (adRows.length === 0) {
+    return [];
+  }
+
+  const ads: Map<number, StoredAd> = new Map();
+  for (const row of adRows) {
+    ads.set(row.id, {
+      id: row.id,
+      advertiserName: row.advertiser_name,
+      platform: row.platform,
+      adIdentifier: row.ad_identifier,
+      imageUrl: row.image_url,
+      metadata: parseJson<Record<string, unknown>>(row.metadata),
+      firstSeen: row.first_seen,
+      lastSeen: row.last_seen,
+      insights: [],
+    });
+  }
+
+  const adIds = adRows.map((row) => row.id);
+  const placeholders = adIds.map(() => "?").join(", ");
+  const insightQuery =
+    "SELECT id, ad_id, model, insight_type, insight, raw_response, created_at, updated_at FROM ad_insights WHERE ad_id IN (" +
+    placeholders +
+    ") ORDER BY updated_at DESC";
+
+  const insightStmt = env.DB.prepare(insightQuery).bind(...adIds);
+  const insightResult = await insightStmt.all<{
+    id: number;
+    ad_id: number;
+    model: string;
+    insight_type: string;
+    insight: string;
+    raw_response: string | null;
+    created_at: string;
+    updated_at: string;
+  }>();
+
+  for (const row of insightResult.results ?? []) {
+    const ad = ads.get(row.ad_id);
+    if (!ad) {
+      continue;
+    }
+
+    const rawResponse = parseJson<unknown>(row.raw_response);
+
+    ad.insights.push({
+      id: row.id,
+      model: row.model,
+      insightType: row.insight_type,
+      insight: row.insight,
+      rawResponse,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    });
+  }
+
+  return Array.from(ads.values());
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    console.warn("Failed to stringify value for storage", error);
+    throw new HttpError(400, "Unable to serialize provided JSON value.");
+  }
+}
+
+function parseJson<T>(value: string | null): T | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    console.warn("Failed to parse stored JSON", error);
+    return null;
+  }
+}

--- a/src/renderHtml.ts
+++ b/src/renderHtml.ts
@@ -1,29 +1,461 @@
-export function renderHtml(content: string) {
+export type RenderableInsight = {
+  id: number;
+  model: string;
+  insightType: string;
+  insight: string;
+  rawResponse: unknown | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type RenderableAd = {
+  id: number;
+  advertiserName: string;
+  platform: string;
+  adIdentifier: string;
+  imageUrl: string;
+  metadata: Record<string, unknown> | null;
+  firstSeen: string;
+  lastSeen: string;
+  insights: RenderableInsight[];
+};
+
+interface RenderHtmlInput {
+  advertiser?: string;
+  ads: RenderableAd[];
+}
+
+export function renderHtml({ advertiser, ads }: RenderHtmlInput): string {
+  const heading = advertiser
+    ? `Ads for ${escapeHtml(advertiser)}`
+    : "Stored advertiser creatives";
+  const filterHint =
+    advertiser !== undefined
+      ? `Showing results filtered by "${escapeHtml(advertiser)}".`
+      : "Showing the most recent creatives that were ingested.";
+  const cards = ads.length > 0 ? ads.map(renderAdCard).join("") : emptyStateHtml();
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${heading}</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+        background-color: #f1f5f9;
+        color: #0f172a;
+      }
+
+      header {
+        background: linear-gradient(135deg, #0f172a, #2563eb);
+        color: #f8fafc;
+        padding: 2.5rem 1.5rem 2rem 1.5rem;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0 0 0.75rem 0;
+        font-size: clamp(1.8rem, 2.4vw, 2.6rem);
+      }
+
+      header p {
+        margin: 0;
+        color: rgba(248, 250, 252, 0.85);
+        font-size: 1rem;
+      }
+
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 3rem 1.5rem;
+      }
+
+      .intro {
+        background-color: #fff;
+        border-radius: 0.75rem;
+        padding: 1.25rem 1.5rem;
+        margin-bottom: 2rem;
+        box-shadow: 0 12px 35px -20px rgba(15, 23, 42, 0.45);
+      }
+
+      .intro p {
+        margin: 0;
+        color: #475569;
+        line-height: 1.6;
+      }
+
+      .intro code {
+        background-color: rgba(37, 99, 235, 0.08);
+        padding: 0.2rem 0.4rem;
+        border-radius: 0.4rem;
+        font-size: 0.9rem;
+      }
+
+      .empty-state {
+        background: #fff;
+        border-radius: 0.75rem;
+        padding: 2rem;
+        text-align: center;
+        color: #475569;
+        line-height: 1.6;
+        box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.3);
+      }
+
+      .ad-card {
+        background: #fff;
+        border-radius: 1rem;
+        padding: 1.75rem;
+        margin-bottom: 2rem;
+        box-shadow: 0 24px 40px -28px rgba(15, 23, 42, 0.32);
+      }
+
+      .ad-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      @media (min-width: 900px) {
+        .ad-grid {
+          grid-template-columns: 320px minmax(0, 1fr);
+        }
+      }
+
+      .ad-image {
+        background: #eef2ff;
+        border-radius: 0.8rem;
+        padding: 0.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .ad-image img {
+        max-width: 100%;
+        border-radius: 0.65rem;
+        box-shadow: 0 15px 30px -22px rgba(15, 23, 42, 0.45);
+      }
+
+      .ad-content h2 {
+        margin: 0;
+        font-size: 1.35rem;
+        color: #1e293b;
+      }
+
+      .ad-meta {
+        margin: 0.75rem 0 1.25rem 0;
+        font-size: 0.9rem;
+        color: #475569;
+        line-height: 1.5;
+      }
+
+      .ad-meta strong {
+        color: #0f172a;
+      }
+
+      .metadata,
+      .insights {
+        margin-top: 1.5rem;
+      }
+
+      .metadata p {
+        margin: 0 0 0.8rem 0;
+      }
+
+      .metadata ul {
+        margin: 0.5rem 0 0 1.25rem;
+      }
+
+      .metadata details,
+      .insight details {
+        margin-top: 1rem;
+        background: rgba(148, 163, 184, 0.12);
+        border-radius: 0.6rem;
+        padding: 0.75rem 1rem;
+      }
+
+      .metadata details summary,
+      .insight details summary {
+        cursor: pointer;
+        font-weight: 600;
+        color: #1d4ed8;
+      }
+
+      .metadata pre,
+      .insight pre {
+        overflow-x: auto;
+        font-family: "JetBrains Mono", "Fira Code", monospace;
+        font-size: 0.85rem;
+        line-height: 1.5;
+        margin-top: 0.75rem;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+
+      .snippets-title {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-weight: 600;
+        color: #0f172a;
+      }
+
+      .snippets-title span {
+        display: inline-block;
+        background: rgba(37, 99, 235, 0.12);
+        color: #1d4ed8;
+        padding: 0.1rem 0.5rem;
+        border-radius: 9999px;
+        font-size: 0.75rem;
+        letter-spacing: 0.02em;
+      }
+
+      .insights-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .insight {
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        border-radius: 0.9rem;
+        padding: 1.2rem 1.35rem;
+        background: rgba(248, 250, 252, 0.85);
+      }
+
+      .insight-header {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem 1rem;
+        align-items: baseline;
+        margin-bottom: 0.85rem;
+      }
+
+      .insight-header .model {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        background: rgba(37, 99, 235, 0.12);
+        color: #1d4ed8;
+        padding: 0.2rem 0.6rem;
+        border-radius: 9999px;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
+      .insight-header .type {
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: #475569;
+      }
+
+      .insight-header .timestamp {
+        font-size: 0.8rem;
+        color: #64748b;
+      }
+
+      .insight-body {
+        margin: 0;
+        font-size: 0.98rem;
+        line-height: 1.6;
+        color: #0f172a;
+      }
+
+      .insights-empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: #64748b;
+      }
+
+      a.image-link {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      footer {
+        margin-top: 3rem;
+        text-align: center;
+        color: #94a3b8;
+        font-size: 0.85rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>${heading}</h1>
+      <p>${filterHint}</p>
+    </header>
+    <main>
+      <section class="intro">
+        <p>
+          Use <code>GET /api/ads?advertiser=名称</code> to fetch structured JSON or
+          <code>POST /api/ads/batch</code> to ingest new creatives scraped from the
+          Google Ads Transparency Center.
+        </p>
+      </section>
+      ${cards}
+      <footer>
+        Worker-backed storage powered by Cloudflare D1 · ${new Date().getFullYear()}
+      </footer>
+    </main>
+  </body>
+</html>`;
+}
+
+function emptyStateHtml(): string {
   return `
-    <!DOCTYPE html>
-    <html lang="en">
-      <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>D1</title>
-        <link rel="stylesheet" type="text/css" href="https://static.integrations.cloudflare.com/styles.css">
-      </head>
-    
-      <body>
-        <header>
-          <img
-            src="https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/30e0d3f6-6076-40f8-7abb-8a7676f83c00/public"
-          />
-          <h1>🎉 Successfully connected d1-template to D1</h1>
-        </header>
-        <main>
-          <p>Your D1 Database contains the following data:</p>
-          <pre><code><span style="color: #0E838F">&gt; </span>SELECT * FROM comments LIMIT 3;<br>${content}</code></pre>
-          <small class="blue">
-            <a target="_blank" href="https://developers.cloudflare.com/d1/tutorials/build-a-comments-api/">Build a comments API with Workers and D1</a>
-          </small>
-        </main>
-      </body>
-    </html>
-`;
+    <div class="empty-state">
+      <h2>No creatives stored yet</h2>
+      <p>
+        Run the scraping script or call the <code>/api/ads/batch</code> endpoint to
+        populate this dashboard. Once data is stored, the most recent creatives and
+        their AI-generated insights will appear here.
+      </p>
+    </div>
+  `;
+}
+
+function renderAdCard(ad: RenderableAd): string {
+  const metadataSection = renderMetadata(ad.metadata);
+  const insightsSection = renderInsights(ad.insights);
+
+  return `
+    <article class="ad-card">
+      <div class="ad-grid">
+        <div class="ad-image">
+          <a class="image-link" href="${escapeHtml(ad.imageUrl)}" target="_blank" rel="noopener noreferrer">
+            <img src="${escapeHtml(ad.imageUrl)}" alt="Ad creative" loading="lazy" />
+          </a>
+        </div>
+        <div class="ad-content">
+          <h2>${escapeHtml(ad.advertiserName)}</h2>
+          <p class="ad-meta">
+            <strong>Identifier:</strong> ${escapeHtml(ad.adIdentifier)}<br />
+            <strong>Platform:</strong> ${escapeHtml(ad.platform)}<br />
+            <strong>First seen:</strong> ${formatTimestamp(ad.firstSeen)}<br />
+            <strong>Last seen:</strong> ${formatTimestamp(ad.lastSeen)}
+          </p>
+          ${metadataSection}
+          ${insightsSection}
+        </div>
+      </div>
+    </article>
+  `;
+}
+
+function renderMetadata(metadata: Record<string, unknown> | null): string {
+  if (!metadata) {
+    return '<div class="metadata"><p>No additional metadata captured.</p></div>';
+  }
+
+  const rawSnippetValues = Array.isArray((metadata as { textSnippets?: unknown[] }).textSnippets)
+    ? ((metadata as { textSnippets?: unknown[] }).textSnippets ?? [])
+    : [];
+  const textSnippets = rawSnippetValues
+    .map((value) => (typeof value === "string" ? value.trim() : undefined))
+    .filter((value): value is string => typeof value === "string" && value.length > 0);
+  const alt = typeof (metadata as { alt?: unknown }).alt === "string" ? (metadata as { alt?: string }).alt : undefined;
+
+  let html = '<div class="metadata">';
+  if (alt && alt.trim().length > 0) {
+    html += `<p><strong>Image alt text:</strong> ${escapeHtml(alt.trim())}</p>`;
+  }
+
+  if (textSnippets.length > 0) {
+    html += '<div class="snippets">';
+    html += '<span class="snippets-title">Recognised text<span>OCR</span></span>';
+    html += '<ul>' + textSnippets.map((snippet) => `<li>${escapeHtml(snippet)}</li>`).join("") + '</ul>';
+    html += '</div>';
+  }
+
+  html += `
+    <details>
+      <summary>Metadata JSON</summary>
+      <pre>${escapeHtml(JSON.stringify(metadata, null, 2))}</pre>
+    </details>
+  `;
+  html += '</div>';
+
+  return html;
+}
+
+function renderInsights(insights: RenderableInsight[]): string {
+  if (insights.length === 0) {
+    return '<p class="insights-empty">No model insights stored yet.</p>';
+  }
+
+  const items = insights.map(renderInsight).join("");
+  return `<ul class="insights-list">${items}</ul>`;
+}
+
+function renderInsight(insight: RenderableInsight): string {
+  const header = `
+    <div class="insight-header">
+      <span class="model">${escapeHtml(insight.model)}</span>
+      <span class="type">${escapeHtml(insight.insightType)}</span>
+      <span class="timestamp" title="Generated ${escapeHtml(insight.createdAt)}">
+        Updated ${formatTimestamp(insight.updatedAt)}
+      </span>
+    </div>
+  `;
+  const body = `<p class="insight-body">${formatMultiline(insight.insight)}</p>`;
+  const raw =
+    insight.rawResponse !== null && insight.rawResponse !== undefined
+      ? `
+          <details>
+            <summary>Raw response</summary>
+            <pre>${escapeHtml(JSON.stringify(insight.rawResponse, null, 2))}</pre>
+          </details>
+        `
+      : "";
+
+  return `<li class="insight">${header}${body}${raw}</li>`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    return escapeHtml(value);
+  }
+
+  const formatted = date.toLocaleString("en-US", {
+    timeZone: "UTC",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+
+  return formatted.replace(",", "").replace(/ /g, " ") + " UTC";
+}
+
+function formatMultiline(value: string): string {
+  return escapeHtml(value).replace(/\n/g, "<br />");
 }


### PR DESCRIPTION
## Summary
- replace the template demo with D1-backed ads and ad_insights tables plus REST endpoints for ingesting/fetching creatives
- render a richer dashboard that lists stored creatives, metadata, and model insights
- add a Playwright-based scraper CLI and documentation describing the workflow

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9185f59e0832496799c031aaeaa0c